### PR TITLE
fix: View on This Siteボタンの配置改善とmedia/ディレクトリアクセス時のリダイレクト実装

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,13 @@
+# DirectoryIndexを設定してindex.htmlを優先
+DirectoryIndex index.html
+
+# ディレクトリ一覧表示を無効化
+Options -Indexes
+
+# リライトルール（必要に応じて）
+RewriteEngine On
+
+# media/ディレクトリにアクセスした際にindex.htmlを表示
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteCond %{REQUEST_FILENAME}/index.html -f
+RewriteRule ^(.*)$ $1/index.html [L] 

--- a/index.html
+++ b/index.html
@@ -204,9 +204,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="github-link">
-                    <a href="https://github.com/atsushimemet/" target="_blank" class="btn btn-primary">View on GitHub</a>
-                </div>
                 <div class="media-link">
                     <a href="media/" class="btn btn-primary">View on This Site</a>
                 </div>

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
                     </div>
                 </div>
                 <div class="media-link">
-                    <a href="media/" class="btn btn-primary">View on This Site</a>
+                    <a href="media/index.html" class="btn btn-primary">View on This Site</a>
                 </div>
             </div>
         </div>

--- a/media/.htaccess
+++ b/media/.htaccess
@@ -1,5 +1,5 @@
 # DirectoryIndexを設定してindex.htmlを優先
-DirectoryIndex index.html
+DirectoryIndex index.html redirect.html
 
 # ディレクトリ一覧表示を無効化
 Options -Indexes

--- a/media/.htaccess
+++ b/media/.htaccess
@@ -1,0 +1,13 @@
+# DirectoryIndexを設定してindex.htmlを優先
+DirectoryIndex index.html
+
+# ディレクトリ一覧表示を無効化
+Options -Indexes
+
+# リライトルール
+RewriteEngine On
+
+# ディレクトリにアクセスした際にindex.htmlを表示
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteCond %{REQUEST_FILENAME}/index.html -f
+RewriteRule ^(.*)$ $1/index.html [L] 

--- a/media/admin/index.html
+++ b/media/admin/index.html
@@ -199,7 +199,7 @@
             </div>
             
             <div class="back-link">
-                <a href="../" class="btn btn-secondary">記事一覧に戻る</a>
+                <a href="../index.html" class="btn btn-secondary">記事一覧に戻る</a>
             </div>
         </div>
     </section>

--- a/media/index.html
+++ b/media/index.html
@@ -6,6 +6,12 @@
     <title>Media - Portfolio</title>
     <link rel="stylesheet" href="../style.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <script>
+        // URLがディレクトリ形式（末尾にスラッシュ）の場合、index.htmlにリダイレクト
+        if (window.location.pathname.endsWith('/media/') || window.location.pathname.endsWith('/media')) {
+            window.location.href = window.location.pathname.replace(/\/$/, '') + '/index.html';
+        }
+    </script>
     <style>
         .media-article {
             background: white;

--- a/media/index.html
+++ b/media/index.html
@@ -115,7 +115,7 @@
             <h2 class="section-title">記事一覧</h2>
             
             <div class="admin-link">
-                <a href="admin/" class="btn btn-primary">記事を投稿</a>
+                <a href="admin/index.html" class="btn btn-primary">記事を投稿</a>
             </div>
             
             <div id="articles-container">

--- a/media/redirect.html
+++ b/media/redirect.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirecting...</title>
+    <script>
+        // ページ読み込み時にindex.htmlにリダイレクト
+        window.location.href = 'index.html';
+    </script>
+</head>
+<body>
+    <p>リダイレクト中...</p>
+    <p><a href="index.html">手動で移動する場合はこちらをクリック</a></p>
+</body>
+</html> 

--- a/style.css
+++ b/style.css
@@ -726,12 +726,8 @@ section {
         gap: 3rem;
     }
     
-    .github-link {
-        margin-top: 2rem;
-    }
-    
     .media-link {
-        margin-top: 1rem;
+        margin-top: 2rem;
     }
 }
 
@@ -793,10 +789,6 @@ section {
     
     .media-content {
         gap: 1.5rem;
-    }
-    
-    .github-link {
-        margin-top: 0.5rem;
     }
     
     .media-link {

--- a/style.css
+++ b/style.css
@@ -188,13 +188,13 @@ body {
 
 .btn-secondary {
     background: transparent;
-    color: white;
-    border: 2px solid white;
+    color: #2c3e50;
+    border: 2px solid #2c3e50;
 }
 
 .btn-secondary:hover {
-    background: white;
-    color: #2c3e50;
+    background: #2c3e50;
+    color: white;
     transform: translateY(-2px);
 }
 

--- a/style.css
+++ b/style.css
@@ -187,15 +187,18 @@ body {
 }
 
 .btn-secondary {
-    background: transparent;
+    background: #ecf0f1;
     color: #2c3e50;
-    border: 2px solid #2c3e50;
+    border: 2px solid #bdc3c7;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .btn-secondary:hover {
     background: #2c3e50;
     color: white;
+    border-color: #2c3e50;
     transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 /* Sections */


### PR DESCRIPTION
## 変更内容
- View on This Siteボタンの配置を改善
- MediaセクションからView on GitHubボタンを削除
- View on This SiteボタンをAppセクションと同じ配置方法で配置
- media/ディレクトリアクセス時にindex.htmlを表示するようにリダイレクト実装
- 記事投稿ページの一覧に戻るボタンのリンクを修正
- ボタンの視認性を向上させるため背景色とシャドウを追加

## 詳細
- スマホUI: Zennの下にView on This Siteボタンを配置
- PC UI: X、note、Zennのコンポーネントの下にView on This Siteボタンを配置
- media/にアクセスした際にディレクトリ一覧ではなくindex.htmlを表示
- 記事投稿ページから記事一覧ページへの遷移を改善
- ボタンの視認性を大幅に向上

## 変更ファイル
- index.html: View on This Siteボタンの配置とリンク修正
- style.css: レスポンシブデザインとボタンスタイルの調整
- media/index.html: リダイレクト用JavaScriptを追加
- media/admin/index.html: 一覧に戻るボタンのリンクを修正
- .htaccess: ディレクトリアクセス時の設定を追加
- media/.htaccess: mediaディレクトリ専用の設定を追加
- media/redirect.html: リダイレクト用HTMLファイルを追加

## 実装内容
- HTML/CSS/JavaScriptのみでGitHub Pages対応
- レスポンシブデザインで適切な配置
- 視認性の高いボタンデザイン