### PR TITLE
Fix article post copy order

### DIFF
--- a/media/index.html
+++ b/media/index.html
@@ -230,6 +230,9 @@
         // 記事をクリップボードにコピー
         function copyArticle(index) {
             const articles = JSON.parse(localStorage.getItem('mediaArticles')) || [];
+            // 表示と同じ順序（日付降順）でソート
+            articles.sort((a, b) => new Date(b.date) - new Date(a.date));
+            
             if (index >= 0 && index < articles.length) {
                 const article = articles[index];
                 const textToCopy = `${article.title}\n\n${article.content}`;


### PR DESCRIPTION
Sort articles in `copyArticle` function to match display order and fix incorrect article copying.

Previously, clicking the copy icon for a displayed article would copy a different article because the `copyArticle` function accessed articles based on their original storage order, not the sorted order used for display. This led to an index mismatch, causing the latest displayed article to copy the oldest, and vice versa. Sorting the articles within `copyArticle` ensures consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-35af4fdf-cfb8-43fe-a666-63319cb516e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35af4fdf-cfb8-43fe-a666-63319cb516e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

