### PR TITLE
Adjust reading app layout for mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -380,7 +380,7 @@ section {
 
 .app-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
     gap: 2rem;
     max-width: 1000px;
     width: 100%;
@@ -799,12 +799,12 @@ section {
     }
     
     .app-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr !important;
         gap: 1.5rem;
     }
     
     .resources-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr !important;
         gap: 1.5rem;
     }
     
@@ -863,8 +863,13 @@ section {
 }
 
 @media (max-width: 992px) {
+    .app-grid {
+        grid-template-columns: 1fr !important;
+        gap: 1.5rem;
+    }
+    
     .resources-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr !important;
         gap: 1.5rem;
     }
     
@@ -990,7 +995,7 @@ html {
 
 .resources-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
     gap: 2rem;
     max-width: 800px;
     margin: 0 auto;


### PR DESCRIPTION
Ensures app and resource grids display vertically on mobile and tablet devices to prevent content cutoff.

The previous `minmax(300px, 1fr)` setting allowed items to display horizontally on some mobile screens. This PR increases the `minmax` value and adds `!important` to media queries for `max-width: 992px` and `max-width: 768px` to guarantee vertical stacking across various mobile and tablet screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-14f225e1-61a3-43cc-a130-0de2877130c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14f225e1-61a3-43cc-a130-0de2877130c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

